### PR TITLE
Update SonosService.java

### DIFF
--- a/src/main/java/me/michaeldick/sonosonedrive/SonosService.java
+++ b/src/main/java/me/michaeldick/sonosonedrive/SonosService.java
@@ -603,7 +603,9 @@ public class SonosService implements SonosSoap {
         	
             for (int i = 0; i < mainResultList.size(); i++) { 
             	Item m = new Item(mainResultList.get(i).getAsJsonObject());
-            	if(m.getType()==Item.FileType.audio 
+            	if(m.getType()==null) { 
+            		logger.debug("Ignoring item with null type (e.g. .url files): "+m.getName());
+            	} else if(m.getType()==Item.FileType.audio 
             			|| (m.getType()==Item.FileType.file && m.getName().endsWith(".flac"))
             			|| (m.getType().equals(Item.FileType.file) && m.getMimeType().contains("audio"))) {
             		mcList.add(buildMMD(m));


### PR DESCRIPTION
Prevent NPE on items with null type (occurs with .url files at least, which exist in OneDrive as shortcuts to OneNote notebooks).